### PR TITLE
added a comment to the index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
           <p>Crosser and La Migra are a product of SWEAT, a loose collaborative dedicated to the creation of socially conscious games.</p>
           <p> The members of SWEAT that have contributed to Crosser and La Migra are: Francisco Ortega-Grimaldo, Carmen Escobar, Miguel Tarango, Marco Ortega, Ryan Molloy, Tomás Márquez-Carmona, Scott Leutenegger, Chris GauthierDickey, and Rafael Fajardo.</p>
         </div>
-        <div id = "canvas-column" align = "center">
+        <div id = "canvas-column" align = "center"> <!-- the align attribute is deprecated in html5 but the css is inpenetrable -->
           <!-- p5js canvas element will go here -->
         </div>
         <div id = "right-column">


### PR DESCRIPTION
added comment to index.html explaining that the align = "center" attribute is deprecated in html5 in favor of pushing it to CSS.

https://www.geeksforgeeks.org/html-div-align-attribute/
http://w3schools-fa.ir/tags/att_div_align.html

however I was unable to find a CSS solution, so I have used the deprecated syntax which still works in the version of Chrome I am developing on.