### PR TITLE
tweaked colors in CSS closer to desired grays for background and text

### DIFF
--- a/public/installationStyle.css
+++ b/public/installationStyle.css
@@ -1,9 +1,10 @@
 body {
-  background-color: white;
+  background-color: #4d4d4d;
 }
 p {
   font-family: "Lucida Sans Unicode", "Lucida Grande", sans-serif;
-  font-size: 10pt;
+  font-size: 8pt;
+  color: #cccccc;
 }
   input[type=submit]{
       background-color: #4CAF50;


### PR DESCRIPTION
tweaked colors for background #4d4d4d (~30% lightness) and text #cccccc (~80% lightness). This for the "frame" around the games expressed by html files. CSS still has colored borders around divs which are meant to go away as soon as I feel the content is in the right places.