### PR TITLE
edit CSS to make borders = 0px wide

### DIFF
--- a/public/installationStyle.css
+++ b/public/installationStyle.css
@@ -33,7 +33,7 @@ p {
     width: 300px;
     padding: 10px;
     margin: 0;
-    border: 1px solid #00FF00;
+    border: 0px solid #00FF00;
   }
   #canvas-column{
     position: fixed;
@@ -43,7 +43,7 @@ p {
     width: 620px;
     padding: 10px;
     margin: 0;
-    border: 1px solid #FF0000;
+    border: 0px solid #FF0000;
     align-items: center;
   }
   #right-column{
@@ -54,5 +54,5 @@ p {
     width: 300px;
     padding: 10px;
     margin: 0;
-    border: 1px solid #0000FF;
+    border: 0px solid #0000FF;
   }


### PR DESCRIPTION
edited CSS to make borders around divs disappear by making them 0 pixels wide. This makes it easier to evaluate the visual aesthetic.