### PR TITLE
added console warning when no gamepads connected to main.js

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -69,6 +69,7 @@ function draw(){
   		// use keyboard
   		// or use touches
       //console.log(pads);
+      console.log('warning, no gamepads connected');
   	}
     let browser = navigator.vendor; // window.navigator.vendor may be correct syntax
     if (browser !== 'Google Inc.'){console.log('warning, wrong browser')}


### PR DESCRIPTION
added a console message in main.js that appears when no gamepads are connected. May be handy, may be cruft.